### PR TITLE
Fixed model evaluation when plotting with arbitrary parameters

### DIFF
--- a/ndspec/FitCrossSpectrum.py
+++ b/ndspec/FitCrossSpectrum.py
@@ -1390,7 +1390,7 @@ class FitCrossSpectrum(SimpleFit,EnergyDependentFit,FrequencyDependentFit):
         model = self.eval_model(params=params)
         
         if plot_data is True:
-            model_res,res_errors = self.get_residuals(residuals)
+            model_res,res_errors = self.get_residuals(residuals,model=model)
             if residuals == "delchi":
                 reslabel = "$\\Delta\\chi$"
             else:

--- a/ndspec/FitTimeAvgSpectrum.py
+++ b/ndspec/FitTimeAvgSpectrum.py
@@ -388,7 +388,7 @@ class FitTimeAvgSpectrum(SimpleFit,EnergyDependentFit):
         #if we're also plotting data, get the data in the same units
         #as well as the residuals
         if plot_data is True:
-            model_res,res_errors = self.get_residuals(residuals)
+            model_res,res_errors = self.get_residuals(residuals,model=model)
             if residuals == "delchi":
                 reslabel = "$\\Delta\\chi$"
             elif residuals == "ratio":


### PR DESCRIPTION
Some of the plotting methods were not letting users pass their own set of parameters before evaluating the model and plotting it vs the data. This is now fixed. 