### PR TITLE
Allow recent Numpy

### DIFF
--- a/ndspec/Operator.py
+++ b/ndspec/Operator.py
@@ -1,6 +1,12 @@
 import numpy as np
 from scipy.interpolate import interp1d
 
+try:
+    trapezoid = np.trapezoid
+except AttributeError:
+    trapezoid = np.trapz
+
+
 class nDspecOperator(object):
     """
     Generic class from which all nDspec operators are inherited. It contains 
@@ -337,9 +343,9 @@ class nDspecOperator(object):
             raise ValueError("No bins found within the integration bounds")
         
         if (axis == 0):
-            integral =  np.trapezoid(signal[arr_range,:],x=array[arr_range])
+            integral = trapezoid(signal[arr_range,:],x=array[arr_range])
         elif (axis == 1):
-            integral =  np.trapezoid(signal[:,arr_range],x=array[arr_range])
+            integral = trapezoid(signal[:,arr_range],x=array[arr_range])
         else:
             raise ValueError("Incorrect axis specified")        
         return integral


### PR DESCRIPTION
nDspec fails on recent numpy versions due to the absence of np.trapz. This should fix it

Ref: https://numpy.org/devdocs/release/2.4.0-notes.html#removal-of-deprecated-functions-and-arguments

Resolves https://github.com/nDspec/nDspec/issues/90#issuecomment-3927051643